### PR TITLE
added project.manifest

### DIFF
--- a/barrels/Semicircles/monkey.jungle
+++ b/barrels/Semicircles/monkey.jungle
@@ -1,0 +1,1 @@
+project.manifest = manifest.xml


### PR DESCRIPTION
When trying to run `barrelbuild -f monkey.jungle -o bin/Semicircles.barrel` in barrels/Semicircles the build fails with the error 

    ERROR: Barrel build failed: The project manifest must be specified within a Jungle file using the syntax 'project.manifest = path/to/manifest'.