### PR TITLE
Private var access

### DIFF
--- a/barrels/Semicircles/Semicircles.mc
+++ b/barrels/Semicircles/Semicircles.mc
@@ -95,8 +95,7 @@ module Semicircles {
                     }
                     break;
                 case instanceof Semicircles.Coordinate:
-                    result[0] = value._lat;
-                    result[1] = value._lon;
+                    result = value.toSemicircles();
                     break;
                 case instanceof Lang.Array:
                     result[0] = value[0];

--- a/barrels/Semicircles/monkey.jungle
+++ b/barrels/Semicircles/monkey.jungle
@@ -1,0 +1,1 @@
+project.manifest = manifest.xml


### PR DESCRIPTION
The following code (using Semicircles)

    var myLocation1 = new Position.Location({
      :latitude => 38.856147,
      :longitude => -94.800953,
      :format => :degrees});
    var mySC1 = new Semicircles.Coordinate(myLocation1);
    var mySC2 = new Semicircles.Coordinate(mySC1);

will fail with the error

    Error: Symbol Not Found Error
    Details: Could not find symbol '_lat'

since _lat and _lon are declared private (lines 50 and 51 in Semicircles.mc).