### PR TITLE
Forcing env to use Python 2

### DIFF
--- a/audio-provider/monkeymusic/cgi-bin/media.py
+++ b/audio-provider/monkeymusic/cgi-bin/media.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import cgi
 import cgitb; cgitb.enable() # Optional for debugging only


### PR DESCRIPTION
[Python 2 is now end-of-life](https://www.python.org/doc/sunset-python-2/), so on many new systems, `/usr/bin/python` now points to python3, not python2.

Without this change, trying to run the media server on such systems results in a bunch of errors, related to the python3 interpreter trying to read python2 code.

Of course, a better goal would be to upgrade the server to Python 3