### PR TITLE
Fix error with time format

### DIFF
--- a/watchfaces/TypedFace/source/Complications/ComplicatedDate.mc
+++ b/watchfaces/TypedFace/source/Complications/ComplicatedDate.mc
@@ -23,7 +23,7 @@ module Complicated {
 
         //! Update the model 
         public function updateModel() as Complicated.Model {
-            var info = Gregorian.info(Time.now(), Gregorian.FORMAT_SHORT);
+            var info = Gregorian.info(Time.now(), Time.FORMAT_SHORT);
             var dateString = Lang.format("$1$/$2$", [info.month, info.day]);
             return new LabelModel(dateString, _icon);
         }


### PR DESCRIPTION
The following error is outputted when running: 
ERROR: fr245m: ComplicatedDate.mc:26,12: Cannot find symbol ':FORMAT_SHORT' on type '$.Toybox.Time.Gregorian'.

According to https://developer.garmin.com/connect-iq/api-docs/Toybox/Time/Gregorian.html it should be Time.FORMAT_SHORT not Gregorian.FORMAT_SHORT